### PR TITLE
#21 - 회원 계정 도메인 구현 및 erd 반영

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
@@ -1,0 +1,53 @@
+package com.fastcampus.projectboard.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Getter
+@ToString
+@Table(indexes = {
+        @Index(columnList = "userId"),
+        @Index(columnList = "email", unique = true),
+        @Index(columnList = "createdAt"),
+        @Index(columnList = "createdBy")
+})
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserAccount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter @Column(nullable = false, length = 50) private String userId;
+    @Setter @Column(nullable = false) private String userPassword;
+
+    @Setter @Column(length = 100) private String email;
+    @Setter @Column(length = 100) private String nickname;
+    @Setter private String memo;
+
+    public UserAccount(String userId, String userPassword, String email, String nickname, String memo) {
+        this.userId = userId;
+        this.userPassword = userPassword;
+        this.email = email;
+        this.nickname = nickname;
+        this.memo = memo;
+    }
+
+    public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo) {
+        return new UserAccount(userId, userPassword, email, nickname, memo);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserAccount that)) return false;
+        return id != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
+    }
+}

--- a/src/main/java/com/fastcampus/projectboard/repository/UserAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/UserAccountRepository.java
@@ -1,0 +1,7 @@
+package com.fastcampus.projectboard.repository;
+
+import com.fastcampus.projectboard.domain.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,9 @@
+-- 테스트 계정
+-- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
+insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
+    ('uno', 'asdf1234', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno')
+;
+
 -- 123 게시글
 insert into article (title, content, hashtag, created_by, modified_by, created_at, modified_at) values
                                                                                                     ('Quisque ut erat.', 'Vestibulum quam sapien, varius ut, blandit non, interdum in, ante. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Duis faucibus accumsan odio. Curabitur convallis.

--- a/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,7 +35,7 @@ public class DataRestTest {
         // Given
 
         // When & Then
-        mvc.perform(MockMvcRequestBuilders.get("/api/articles"))
+        mvc.perform(get("/api/articles"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
                 //.andDo(print());
@@ -46,7 +47,7 @@ public class DataRestTest {
         // Given
 
         // When & Then
-        mvc.perform(MockMvcRequestBuilders.get("/api/articles/1"))
+        mvc.perform(get("/api/articles/1"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
 
@@ -58,7 +59,7 @@ public class DataRestTest {
         // Given
 
         // When & Then
-        mvc.perform(MockMvcRequestBuilders.get("/api/articles/1/articleComments"))
+        mvc.perform(get("/api/articles/1/articleComments"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
 
@@ -70,7 +71,7 @@ public class DataRestTest {
         // Given
 
         // When & Then
-        mvc.perform(MockMvcRequestBuilders.get("/api/articleComments"))
+        mvc.perform(get("/api/articleComments"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
     }
@@ -81,9 +82,23 @@ public class DataRestTest {
         // Given
 
         // When & Then
-        mvc.perform(MockMvcRequestBuilders.get("/api/articleComments/1"))
+        mvc.perform(get("/api/articleComments/1"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 회원 관련 API는 일체 제공하지 않는다.")
+    @Test
+    public void givenNothing_whenRequestingUserAccounts_thenThrowsException() throws Exception {
+        // Given
+
+        // When
+        mvc.perform(get("api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(post("api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(put("api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(patch("api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(delete("api/userAccounts")).andExpect(status().isNotFound());
+        mvc.perform(head("api/userAccounts")).andExpect(status().isNotFound());
     }
 
 }


### PR DESCRIPTION
`UserAccount` 이름으로 회원 계정 도메인 생성
`user`, `account` 등은 mysql 예약어이므로 피함
필드명도 mysql 예약어를 의식하여 정함

테스트 데이터에 임의 계정 1개 등록
테스트용이지만 패스워드가 노출되는 방식이므로 고민 필요

회원 정보는 API 로 노출되지 않았으면 한다.
이에 테스트에 404 not found 를 확인하는 테스트 추가
간단하게 모든 http 메소드에 대응